### PR TITLE
Feature/load env data

### DIFF
--- a/.eslintrc-back.js
+++ b/.eslintrc-back.js
@@ -10,5 +10,8 @@ module.exports = defineConfig({
     "plugins": {
         personnallinter
     },
-    "extends": [ personnallinter.configs["ts-back"] ]
+    "extends": [ personnallinter.configs["ts-back"] ],
+    "rules": {
+        "n/no-process-env": "warn"
+    }
 });

--- a/lib/src/NodeConfManager.ts
+++ b/lib/src/NodeConfManager.ts
@@ -67,10 +67,17 @@ export default class ConfManager extends NodeContainerPattern {
 
         return new Promise((resolve: () => void, reject: (error: Error) => void) => {
 
-            createInterface({
-                "input": createReadStream(file),
+            let stop = false;
+
+            const input = createReadStream(file);
+
+            // To stop reading early from inside "line", call rl.close(); "close" then fires and the Promise resolves.
+            const rl = createInterface({
+                "input": input,
                 "crlfDelay": Infinity
-            }).on("line", (l: string) => {
+            });
+
+            rl.on("line", (l: string) => {
 
                 const line: string = l.trim();
 
@@ -80,12 +87,40 @@ export default class ConfManager extends NodeContainerPattern {
 
                 const [ key, value ]: string[] = line.split("=");
 
-                this.set(key.trim().toLocaleLowerCase(), value);
+                try {
+                    this.set(key.trim().toLocaleLowerCase(), value);
+                }
+                catch (e: unknown) {
 
-            }).on("error", (error: Error): void => {
-                return reject(error);
-            }).on("close", (): void => {
-                return resolve();
+                    stop = true;
+
+                    if (e instanceof Error) {
+                        reject(e);
+                    }
+                    else {
+                        reject(new Error(String(e)));
+                    }
+
+                }
+
+            });
+
+            rl.on("error", (error: Error): void => {
+
+                if (!stop) {
+                    stop = true;
+                    reject(error);
+                }
+
+            });
+
+            rl.on("close", (): void => {
+
+                if (!stop) {
+                    stop = true;
+                    resolve();
+                }
+
             });
 
         });

--- a/lib/src/NodeConfManager.ts
+++ b/lib/src/NodeConfManager.ts
@@ -74,7 +74,7 @@ export default class ConfManager extends NodeContainerPattern {
 
                 const line: string = l.trim();
 
-                if (line.startsWith("#")) {
+                if (0 >= line.length || line.startsWith("#") || !line.includes("=")) {
                     return;
                 }
 

--- a/lib/src/NodeConfManager.ts
+++ b/lib/src/NodeConfManager.ts
@@ -4,6 +4,9 @@
     import { dirname } from "node:path";
     import { unlink, readFile, writeFile, mkdir } from "node:fs/promises";
 
+    import { createReadStream } from "node:fs";
+    import { createInterface } from "node:readline";
+
     // externals
     import NodeContainerPattern from "node-containerpattern";
 
@@ -59,6 +62,43 @@ export default class ConfManager extends NodeContainerPattern {
     }
 
     // private
+
+    private _loadFromEnvFile (file: string): Promise<void> {
+
+        return new Promise((resolve: () => void, reject: (error: Error) => void) => {
+
+            createInterface({
+                "input": createReadStream(file),
+                "crlfDelay": Infinity
+            }).on("line", (l: string) => {
+
+                const line: string = l.trim();
+
+                if (line.startsWith("#")) {
+                    return;
+                }
+
+                const [ key, value ]: string[] = line.split("=");
+
+                this.set(key.trim().toLocaleLowerCase(), value);
+
+            }).on("error", (error: Error): void => {
+                return reject(error);
+            }).on("close", (): void => {
+                return resolve();
+            });
+
+        });
+
+    }
+
+    private _loadFromEnv (): void {
+
+        Object.keys(process.env).forEach((key: string): void => {
+            this.set(key.trim().toLocaleLowerCase(), process.env[key]);
+        });
+
+    }
 
     private _loadFromConsole (): void {
 
@@ -164,8 +204,17 @@ export default class ConfManager extends NodeContainerPattern {
         return clone<T>(super.get<T>(key));
     }
 
-    // load data from conf file then commandline (commandline takeover)
-    public load (loadConsole: boolean = true): Promise<void> {
+    // prio : env > console > envfile > conf file
+    public load (options: boolean //
+        | {
+            "loadConsole"?: boolean; // load data from conf file then commandline (default : true)
+            "loadEnv"?: boolean; // load data from ENV (default : true)
+            "loadEnvFile"?: string; // load data from env file (default : "" => no load)
+        } = {
+            "loadConsole": true,
+            "loadEnv": true,
+            "loadEnvFile": ""
+        }): Promise<void> {
 
         this.clearData();
 
@@ -177,7 +226,7 @@ export default class ConfManager extends NodeContainerPattern {
 
             return readFile(this.filePath, "utf-8").then((content: string): Record<string, unknown> => {
                 return JSON.parse(content) as Record<string, unknown>;
-            }).then((data: Record<string, unknown>): undefined => {
+            }).then((data: Record<string, unknown>): void => {
 
                 for (const key in data) {
                     this.set(key, data[key]);
@@ -185,10 +234,25 @@ export default class ConfManager extends NodeContainerPattern {
 
             });
 
-        }).then(() => {
+        }).then(async () => {
 
-            if (loadConsole) {
+            if ("boolean" === typeof options && options) {
                 this._loadFromConsole();
+            }
+            else if ("object" === typeof options) {
+
+                if ("string" === typeof options.loadEnvFile && "" !== options.loadEnvFile.trim()) {
+                    await this._loadFromEnvFile(options.loadEnvFile);
+                }
+
+                if ("boolean" === typeof options.loadConsole && options.loadConsole) {
+                    this._loadFromConsole();
+                }
+
+                if ("boolean" === typeof options.loadEnv && options.loadEnv) {
+                    this._loadFromEnv();
+                }
+
             }
 
         });

--- a/lib/src/NodeConfManager.ts
+++ b/lib/src/NodeConfManager.ts
@@ -241,15 +241,20 @@ export default class ConfManager extends NodeContainerPattern {
             }
             else if ("object" === typeof options) {
 
-                if ("string" === typeof options.loadEnvFile && "" !== options.loadEnvFile.trim()) {
-                    await this._loadFromEnvFile(options.loadEnvFile);
+                // default values
+                const loadConsole: boolean = "boolean" === typeof options.loadConsole ? options.loadConsole : true;
+                const loadEnv: boolean = "boolean" === typeof options.loadEnv ? options.loadEnv : true;
+                const loadEnvFile: string = "string" === typeof options.loadEnvFile ? options.loadEnvFile : "";
+
+                if ("" !== loadEnvFile.trim()) {
+                    await this._loadFromEnvFile(loadEnvFile);
                 }
 
-                if ("boolean" === typeof options.loadConsole && options.loadConsole) {
+                if (loadConsole) {
                     this._loadFromConsole();
                 }
 
-                if ("boolean" === typeof options.loadEnv && options.loadEnv) {
+                if (loadEnv) {
                     this._loadFromEnv();
                 }
 

--- a/test/2_6_load.js
+++ b/test/2_6_load.js
@@ -271,7 +271,6 @@ describe("load", () => {
             (0, process).argv.push("--");
 
             return conf.load({
-                "loadConsole": true,
                 "loadEnv": false
             });
 
@@ -282,7 +281,6 @@ describe("load", () => {
             (0, process).argv.push("--debug");
 
             return conf.load({
-                "loadConsole": true,
                 "loadEnv": false
             }).then(() => {
 
@@ -727,6 +725,18 @@ describe("load", () => {
             }).then(() => {
 
                 strictEqual(conf.has(envKey.toLowerCase()), false);
+
+            });
+
+        });
+
+        it("should load from process.env when loadEnv is omitted (defaults to true)", () => {
+
+            return conf.load({
+                "loadConsole": false
+            }).then(() => {
+
+                strictEqual(conf.get(envKey.toLowerCase()), envVal);
 
             });
 

--- a/test/2_6_load.js
+++ b/test/2_6_load.js
@@ -601,6 +601,55 @@ describe("load", () => {
 
         });
 
+        it("should ignore empty lines (and lines that trim to empty)", () => {
+
+            return writeFile(envTmp, [
+                "FIRST=one",
+                "",
+                "   ",
+                "",
+                "SECOND=two"
+            ].join("\n"), "utf-8").then(() => {
+
+                return conf.load({
+                    "loadEnvFile": envTmp,
+                    "loadConsole": false,
+                    "loadEnv": false
+                });
+
+            }).then(() => {
+
+                strictEqual(conf.get("first"), "one");
+                strictEqual(conf.get("second"), "two");
+                strictEqual(conf.size, 2);
+
+            });
+
+        });
+
+        it("should ignore lines without \"=\"", () => {
+
+            return writeFile(envTmp, [
+                "not a valid env line",
+                "KEY_AFTER_BAD_LINE=value"
+            ].join("\n"), "utf-8").then(() => {
+
+                return conf.load({
+                    "loadEnvFile": envTmp,
+                    "loadConsole": false,
+                    "loadEnv": false
+                });
+
+            }).then(() => {
+
+                strictEqual(conf.get("key_after_bad_line"), "value");
+                strictEqual(conf.size, 1);
+                strictEqual(conf.has("not a valid env line"), false);
+
+            });
+
+        });
+
         it("should reject when env file path does not exist", () => {
 
             const missing = join(__dirname, "utils", "2_6_definitely_missing_env.env");

--- a/test/2_6_load.js
+++ b/test/2_6_load.js
@@ -2,6 +2,7 @@
 
     // natives
     const { join } = require("node:path");
+    const { writeFile, unlink } = require("node:fs/promises");
     const { strictEqual, deepStrictEqual, ok } = require("node:assert");
 
     // locals
@@ -11,6 +12,8 @@
 // consts
 
     const CONF_FILE = join(__dirname, "conf.json");
+    const NO_CONF_FILE = join(__dirname, "2_6_missing_conf.json");
+    const PRIO_CONF_FILE = join(__dirname, "2_6_priority_conf.json");
 
 // private
 
@@ -19,7 +22,7 @@
         /**
         * Remove mocha's console arguments
         * @param {NodeConfManager} conf : conf to clean
-        * @returns {Promise} Operation's result
+        * @returns {void}
         */
         function _removeMochaConsoleArguments (conf) {
 
@@ -33,8 +36,6 @@
                 conf.delete(key);
             });
 
-            return Promise.resolve();
-
         }
 
 // tests
@@ -42,7 +43,9 @@
 describe("load", () => {
 
     it("should load a configuration without file", () => {
-        return new NodeConfManager().load();
+        return new NodeConfManager().load({
+            "loadEnv": false
+        });
     });
 
     describe("from file", () => {
@@ -86,8 +89,11 @@ describe("load", () => {
 
             }).then(() => {
 
-                return conf.load().then(() => {
-                    return _removeMochaConsoleArguments(conf);
+                return conf.load({
+                    "loadConsole": true,
+                    "loadEnv": false
+                }).then(() => {
+                    _removeMochaConsoleArguments(conf);
                 });
 
             }).then(() => {
@@ -113,8 +119,43 @@ describe("load", () => {
 
             conf.limit("debug", [ true, false ]);
 
-            return conf.load().catch(() => {
+            return conf.load({
+                "loadConsole": false,
+                "loadEnv": false
+            }).catch(() => {
                 return Promise.resolve();
+            });
+
+        });
+
+    });
+
+    describe("from env file first", () => {
+
+        const conf = new NodeConfManager(CONF_FILE);
+        const envFile = join(__dirname, "utils", ".env");
+
+        before(() => {
+
+            conf.clear();
+
+            return conf
+                .skeleton("debug", "boolean").shortcut("debug", "d")
+                .skeleton("test", "string").shortcut("test", "t").limit("test", [ "test", "test2" ])
+                .skeleton("plugins", "array");
+
+        });
+
+        beforeEach(() => {
+            conf.clearData();
+        });
+
+        it("should load", () => {
+
+            return conf.load({
+                "loadEnvFile": envFile,
+                "loadConsole": false,
+                "loadEnv": false
             });
 
         });
@@ -147,7 +188,10 @@ describe("load", () => {
             (0, process).argv.push("--debug", "this is a test");
             (0, process).argv.push("--test", "this is a test");
 
-            conf.load().then(() => {
+            conf.load({
+                "loadConsole": true,
+                "loadEnv": false
+            }).then(() => {
                 done(new Error("Does not generate an error"));
             }).catch((err) => {
 
@@ -164,7 +208,10 @@ describe("load", () => {
 
             (0, process).argv.push("--test");
 
-            conf.load().then(() => {
+            conf.load({
+                "loadConsole": true,
+                "loadEnv": false
+            }).then(() => {
                 done(new Error("Does not generate an error"));
             }).catch((err) => {
 
@@ -182,7 +229,10 @@ describe("load", () => {
             (0, process).argv.push("--test");
             (0, process).argv.push("--test2");
 
-            conf.load().then(() => {
+            conf.load({
+                "loadConsole": true,
+                "loadEnv": false
+            }).then(() => {
                 done(new Error("Does not generate an error"));
             }).catch((err) => {
 
@@ -200,7 +250,10 @@ describe("load", () => {
             (0, process).argv.push("--test");
             (0, process).argv.push("-d");
 
-            conf.load().then(() => {
+            conf.load({
+                "loadConsole": true,
+                "loadEnv": false
+            }).then(() => {
                 done(new Error("Does not generate an error"));
             }).catch((err) => {
 
@@ -217,7 +270,10 @@ describe("load", () => {
 
             (0, process).argv.push("--");
 
-            return conf.load();
+            return conf.load({
+                "loadConsole": true,
+                "loadEnv": false
+            });
 
         });
 
@@ -225,7 +281,10 @@ describe("load", () => {
 
             (0, process).argv.push("--debug");
 
-            return conf.load().then(() => {
+            return conf.load({
+                "loadConsole": true,
+                "loadEnv": false
+            }).then(() => {
 
                 ok(conf.get("debug"));
 
@@ -237,7 +296,10 @@ describe("load", () => {
 
             (0, process).argv.push("--plugins");
 
-            conf.load().then(() => {
+            conf.load({
+                "loadConsole": true,
+                "loadEnv": false
+            }).then(() => {
                 done(new Error("Does not generate an error"));
             }).catch((err) => {
 
@@ -255,7 +317,10 @@ describe("load", () => {
             (0, process).argv.push("--plugins");
             (0, process).argv.push("--debug");
 
-            conf.load().then(() => {
+            conf.load({
+                "loadConsole": true,
+                "loadEnv": false
+            }).then(() => {
                 done(new Error("Does not generate an error"));
             }).catch((err) => {
 
@@ -273,7 +338,10 @@ describe("load", () => {
             (0, process).argv.push("--plugins");
             (0, process).argv.push("[ \"test1\", \"test2\" ]");
 
-            return conf.load().then(() => {
+            return conf.load({
+                "loadConsole": true,
+                "loadEnv": false
+            }).then(() => {
 
                 deepStrictEqual(conf.get("plugins"), [ "test1", "test2" ]);
 
@@ -287,7 +355,10 @@ describe("load", () => {
             (0, process).argv.push("test1");
             (0, process).argv.push("test2");
 
-            return conf.load().then(() => {
+            return conf.load({
+                "loadConsole": true,
+                "loadEnv": false
+            }).then(() => {
 
                 deepStrictEqual(conf.get("plugins"), [ "test1", "test2" ]);
 
@@ -307,8 +378,6 @@ describe("load", () => {
                     .set("debug", "n")
                     .set("authors", [ "author1", "author2" ]);
 
-                return Promise.resolve();
-
             }).then(() => {
 
                 strictEqual(conf.size, 3, "check loaded data failed (size)");
@@ -319,15 +388,16 @@ describe("load", () => {
                     "pwd": "pwd"
                 }, "check 'usr' loaded data failed");
 
-                return Promise.resolve();
-
             }).then(() => {
 
                 (0, process).argv.push("--debug", "true");
                 (0, process).argv.push("--test", "test2");
 
-                return conf.load().then(() => {
-                    return _removeMochaConsoleArguments(conf);
+                return conf.load({
+                    "loadConsole": true,
+                    "loadEnv": false
+                }).then(() => {
+                    _removeMochaConsoleArguments(conf);
                 });
 
             }).then(() => {
@@ -336,8 +406,6 @@ describe("load", () => {
 
                 ok(conf.get("debug"));
                 strictEqual(conf.get("test"), "test2", "check loaded data failed (test)");
-
-                return Promise.resolve();
 
             });
 
@@ -355,8 +423,6 @@ describe("load", () => {
                     .set("debug", "n")
                     .set("authors", [ "author1", "author2" ]);
 
-                return Promise.resolve();
-
             }).then(() => {
 
                 strictEqual(conf.size, 3, "check loaded data failed (size)");
@@ -368,15 +434,16 @@ describe("load", () => {
                     "pwd": "pwd"
                 }, "check 'usr' loaded data failed");
 
-                return Promise.resolve();
-
             }).then(() => {
 
                 (0, process).argv.push("-d", "true");
                 (0, process).argv.push("-t", "test2");
 
-                return conf.load().then(() => {
-                    return _removeMochaConsoleArguments(conf);
+                return conf.load({
+                    "loadConsole": true,
+                    "loadEnv": false
+                }).then(() => {
+                    _removeMochaConsoleArguments(conf);
                 });
 
             }).then(() => {
@@ -385,8 +452,6 @@ describe("load", () => {
 
                 ok(conf.get("debug"));
                 strictEqual(conf.get("test"), "test2", "check loaded data failed (test)");
-
-                return Promise.resolve();
 
             });
 
@@ -398,29 +463,26 @@ describe("load", () => {
 
                 conf.set("debug", "n");
 
-                return Promise.resolve();
-
             }).then(() => {
 
                 strictEqual(conf.size, 1, "check loaded data failed (size)");
                 strictEqual(conf.get("debug"), false, "check loaded data failed (debug)");
 
-                return Promise.resolve();
-
             }).then(() => {
 
                 (0, process).argv.push("-d");
 
-                return conf.load().then(() => {
-                    return _removeMochaConsoleArguments(conf);
+                return conf.load({
+                    "loadConsole": true,
+                    "loadEnv": false
+                }).then(() => {
+                    _removeMochaConsoleArguments(conf);
                 });
 
             }).then(() => {
 
                 strictEqual(conf.size, 1, "check loaded data failed (size)");
                 ok(conf.get("debug"));
-
-                return Promise.resolve();
 
             });
 
@@ -438,8 +500,6 @@ describe("load", () => {
                     .set("debug", "n")
                     .set("authors", [ "author1", "author2" ]);
 
-                return Promise.resolve();
-
             }).then(() => {
 
                 strictEqual(conf.size, 3, "check loaded data failed (size)");
@@ -451,15 +511,16 @@ describe("load", () => {
                     "pwd": "pwd"
                 }, "check 'usr' loaded data failed");
 
-                return Promise.resolve();
-
             }).then(() => {
 
                 (0, process).argv.push("--usr.login", "login2");
                 (0, process).argv.push("--lvl1.lvl2.lvl3", "test");
 
-                return conf.load().then(() => {
-                    return _removeMochaConsoleArguments(conf);
+                return conf.load({
+                    "loadConsole": true,
+                    "loadEnv": false
+                }).then(() => {
+                    _removeMochaConsoleArguments(conf);
                 });
 
             }).then(() => {
@@ -475,9 +536,282 @@ describe("load", () => {
                     "login": "login2"
                 }, "check 'usr' loaded data failed");
 
+            });
+
+        });
+
+    });
+
+    describe("from env file content (via load)", () => {
+
+        const envTmp = join(__dirname, "utils", "2_6_tmp_env.env");
+        let conf = null;
+
+        beforeEach(() => {
+            conf = new NodeConfManager(NO_CONF_FILE);
+            conf.clear();
+        });
+
+        afterEach(() => {
+
+            return unlink(envTmp).catch(() => {
                 return Promise.resolve();
+            });
+
+        });
+
+        it("should load variables with lowercased keys and skip comment lines", () => {
+
+            return writeFile(envTmp, [
+                "# ignored comment",
+                "MYKEY=myvalue",
+                "UPPERCASEKEY=lowercase"
+            ].join("\n"), "utf-8").then(() => {
+
+                return conf.load({
+                    "loadEnvFile": envTmp,
+                    "loadConsole": false,
+                    "loadEnv": false
+                });
+
+            }).then(() => {
+
+                strictEqual(conf.get("mykey"), "myvalue");
+                strictEqual(conf.get("uppercasekey"), "lowercase");
 
             });
+
+        });
+
+        it("should take only the first segment after '=' as value (split/destructuring)", () => {
+
+            return writeFile(envTmp, "EQKEY=a=b=c\n", "utf-8").then(() => {
+
+                return conf.load({
+                    "loadEnvFile": envTmp,
+                    "loadConsole": false,
+                    "loadEnv": false
+                });
+
+            }).then(() => {
+
+                strictEqual(conf.get("eqkey"), "a");
+
+            });
+
+        });
+
+        it("should reject when env file path does not exist", () => {
+
+            const missing = join(__dirname, "utils", "2_6_definitely_missing_env.env");
+
+            return conf.load({
+                "loadEnvFile": missing,
+                "loadConsole": false,
+                "loadEnv": false
+            }).then(() => {
+                throw new Error("Expected rejection");
+            }).catch((err) => {
+
+                strictEqual(typeof err, "object", "Generated error is not an object");
+                ok(err instanceof Error);
+
+            });
+
+        });
+
+    });
+
+    describe("from process env (via load)", () => {
+
+        const envKey = "NODECONFMANAGER_2_6_UNIT_ENV";
+        const envVal = "from_process_env";
+        let conf = null;
+        let hadEnvKey = false;
+        let envPrevious = "";
+
+        beforeEach(() => {
+
+            const { env } = (0, process);
+
+            hadEnvKey = Object.hasOwn(env, envKey);
+            envPrevious = hadEnvKey ? env[envKey] : "";
+            env[envKey] = envVal;
+            conf = new NodeConfManager(NO_CONF_FILE);
+            conf.clear();
+
+        });
+
+        afterEach(() => {
+
+            const { env } = (0, process);
+
+            if (hadEnvKey) {
+                env[envKey] = envPrevious;
+            }
+            else {
+                delete env[envKey];
+            }
+
+        });
+
+        it("should expose process.env value under lowercased key", () => {
+
+            return conf.load({
+                "loadEnvFile": "",
+                "loadConsole": false,
+                "loadEnv": true
+            }).then(() => {
+
+                strictEqual(conf.get(envKey.toLowerCase()), envVal);
+
+            });
+
+        });
+
+        it("should not load from process.env when loadEnv is false", () => {
+
+            return conf.load({
+                "loadEnvFile": "",
+                "loadConsole": false,
+                "loadEnv": false
+            }).then(() => {
+
+                strictEqual(conf.has(envKey.toLowerCase()), false);
+
+            });
+
+        });
+
+    });
+
+    describe("load source priority (env > console > envfile > conf file)", () => {
+
+        const prioEnv = join(__dirname, "utils", "2_6_priority.env");
+        const conf = new NodeConfManager(PRIO_CONF_FILE);
+        const argv = clone((0, process).argv);
+
+        before(() => {
+
+            conf.clear();
+            conf.skeleton("marker", "string");
+
+        });
+
+        beforeEach(() => {
+
+            (0, process).argv = clone(argv);
+            conf.clearData();
+
+        });
+
+        afterEach(() => {
+
+            delete (0, process).env.MARKER;
+
+            return Promise.all([
+                unlink(PRIO_CONF_FILE).catch(() => {
+                    return Promise.resolve();
+                }),
+                unlink(prioEnv).catch(() => {
+                    return Promise.resolve();
+                })
+            ]);
+
+        });
+
+        after(() => {
+
+            conf.clear();
+
+            return Promise.all([
+                unlink(PRIO_CONF_FILE).catch(() => {
+                    return Promise.resolve();
+                }),
+                unlink(prioEnv).catch(() => {
+                    return Promise.resolve();
+                })
+            ]);
+
+        });
+
+        it("envfile should overwrite conf file", () => {
+
+            return conf
+                .set("marker", "from_conf_file")
+                .save()
+                .then(() => {
+                    return writeFile(prioEnv, "MARKER=from_env_file\n", "utf-8");
+                })
+                .then(() => {
+
+                    return conf.load({
+                        "loadEnvFile": prioEnv,
+                        "loadConsole": false,
+                        "loadEnv": false
+                    });
+
+                })
+                .then(() => {
+
+                    strictEqual(conf.get("marker"), "from_env_file");
+
+                });
+
+        });
+
+        it("console should overwrite envfile and conf file", () => {
+
+            (0, process).argv.push("--marker", "from_console");
+
+            return conf
+                .set("marker", "from_conf_file")
+                .save()
+                .then(() => {
+                    return writeFile(prioEnv, "MARKER=from_env_file\n", "utf-8");
+                })
+                .then(() => {
+
+                    return conf.load({
+                        "loadEnvFile": prioEnv,
+                        "loadConsole": true,
+                        "loadEnv": false
+                    });
+
+                })
+                .then(() => {
+
+                    _removeMochaConsoleArguments(conf);
+                    strictEqual(conf.get("marker"), "from_console");
+
+                });
+
+        });
+
+        it("process.env should overwrite console, envfile and conf file", () => {
+
+            (0, process).env.MARKER = "from_env";
+            (0, process).argv.push("--marker", "from_console");
+
+            return conf
+                .set("marker", "from_conf_file")
+                .save()
+                .then(() => {
+                    return writeFile(prioEnv, "MARKER=from_env_file\n", "utf-8");
+                }).then(() => {
+
+                    return conf.load({
+                        "loadEnvFile": prioEnv,
+                        "loadConsole": true,
+                        "loadEnv": true
+                    });
+
+                }).then(() => {
+
+                    _removeMochaConsoleArguments(conf);
+                    strictEqual(conf.get("marker"), "from_env");
+
+                });
 
         });
 

--- a/test/utils/.env
+++ b/test/utils/.env
@@ -1,0 +1,3 @@
+#COMMENT
+DEBUG=true
+TEST=test


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes `NodeConfManager.load()` defaults and precedence by introducing `process.env`/`.env` loading that can override existing config values, which may be behavior-breaking for current consumers. Adds new I/O paths (reading env files) and expands test coverage to validate priority and error handling.
> 
> **Overview**
> `NodeConfManager.load()` now supports loading config values from `process.env` and an optional `.env` file, with explicit source precedence **env > console args > env file > JSON conf file**.
> 
> The `load()` API is extended from a simple boolean flag to an options object (`loadEnv`, `loadEnvFile`, `loadConsole`), and tests are updated/added to cover env-file parsing (comments, casing, missing files), process env loading, and priority/override behavior. ESLint config is tweaked to warn on `process.env` usage (`n/no-process-env`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ddf570636297849508c89e8b8de133c56b879e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->